### PR TITLE
refactor: rest api endpoints

### DIFF
--- a/packages/express-backend/accounts/controller.js
+++ b/packages/express-backend/accounts/controller.js
@@ -2,14 +2,6 @@ const Account = require("./schema");
 const { compareHash } = require("../utils/hash");
 
 class AccountController {
-  getAll(callback) {
-    Account.find()
-      .limit(20)
-      .exec((err, accounts) => {
-        if (err) callback(err);
-        else callback(null, accounts);
-      });
-  }
   create(account, callback) {
     const newAccount = new Account(account);
     newAccount.save((err) => {

--- a/packages/express-backend/armies/controller.js
+++ b/packages/express-backend/armies/controller.js
@@ -17,7 +17,7 @@ class ArmyController {
   }
   getAll({ accountId }, callback) {
     Army.find({ accountId })
-      .limit(20)
+      .limit(20) // TODO - paginate?
       .exec((err, armies) => {
         if (err) callback(err);
         else callback(null, armies.map(this.cleanArmy));

--- a/packages/express-backend/armies/routes.js
+++ b/packages/express-backend/armies/routes.js
@@ -3,7 +3,7 @@ const router = express.Router({ mergeParams: true });
 const ArmyController = require("./controller");
 
 router.get("/", (req, res) => {
-  const { accountId } = req.params;
+  const { accountid: accountId } = req.headers;
   ArmyController.getAll({ accountId }, (err, armies) => {
     if (err) return res.status(400).send(err.message);
     else return res.status(200).send(armies);
@@ -11,7 +11,7 @@ router.get("/", (req, res) => {
 });
 
 router.post("/create", (req, res) => {
-  const { accountId } = req.params;
+  const { accountid: accountId } = req.headers;
   const { name } = req.body;
   if (!name) return res.status(400).send("Army name required");
 
@@ -27,7 +27,8 @@ router.post("/create", (req, res) => {
 
 // specific army
 router.get("/:armyId", (req, res) => {
-  const { accountId, armyId } = req.params;
+  const { accountid: accountId } = req.headers;
+  const { armyId } = req.params;
   ArmyController.getOne({ accountId, armyId }, (err, army) => {
     if (err) {
       return res.status(400).send(err.message);

--- a/packages/express-backend/index.js
+++ b/packages/express-backend/index.js
@@ -28,7 +28,7 @@ app.use(bodyParser.json({ extended: true }));
 app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use("/api/v1/accounts", require("./accounts/routes"));
-app.use("/api/v1/:accountId/armies", require("./armies/routes"));
+app.use("/api/v1/armies", require("./armies/routes"));
 app.use("/api/v1/steps", require("./steps/routes"));
 app.use("/api/v1/rules", require("./steps/rulesRoutes"));
 

--- a/packages/express-backend/index.js
+++ b/packages/express-backend/index.js
@@ -29,7 +29,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use("/api/v1/accounts", require("./accounts/routes"));
 app.use("/api/v1/:accountId/armies", require("./armies/routes"));
-app.use("/api/v1/:accountId/:armyId/steps", require("./steps/routes"));
+app.use("/api/v1/steps", require("./steps/routes"));
 app.use("/api/v1/rules", require("./steps/rulesRoutes"));
 
 app.listen(3000);

--- a/packages/express-backend/index.js
+++ b/packages/express-backend/index.js
@@ -30,5 +30,6 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use("/api/v1/accounts", require("./accounts/routes"));
 app.use("/api/v1/:accountId/armies", require("./armies/routes"));
 app.use("/api/v1/:accountId/:armyId/steps", require("./steps/routes"));
+app.use("/api/v1/rules", require("./steps/rulesRoutes"));
 
 app.listen(3000);

--- a/packages/express-backend/steps/routes.js
+++ b/packages/express-backend/steps/routes.js
@@ -3,63 +3,39 @@ const router = express.Router({ mergeParams: true });
 const StepsController = require("./controller");
 const ArmyController = require("../armies/controller");
 
-router.use("/", (req, res, next) => {
-  const { accountId, armyId } = req.params;
+router.get("/:armyId", (req, res) => {
+  const { armyId } = req.params;
+  const { accountid: accountId } = req.headers;
+  console.log({ armyId, accountId });
   ArmyController.validateOwner({ armyId, accountId }, (isOwner) => {
     if (isOwner) {
-      next();
+      StepsController.getArmySteps({ armyId }, (err, armies) => {
+        if (err) return res.status(400).send(err.message);
+        else return res.status(200).send(armies);
+      });
     } else {
       return res.status(403).send("Army not owned by account.");
     }
   });
 });
 
-router.get("/", (req, res) => {
-  const { armyId } = req.params;
-  StepsController.getArmySteps({ armyId }, (err, armies) => {
-    if (err) return res.status(400).send(err.message);
-    else return res.status(200).send(armies);
-  });
-});
-
 router.post("/create", (req, res) => {
-  const { armyId } = req.params;
-  const { name } = req.body;
+  const { name, armyId } = req.body;
+  const { accountId } = req.headers;
   if (!name) return res.status(400).send("Step name required");
 
-  StepsController.create({ name, armyId }, (err, newStep) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).send(err.message);
+  ArmyController.validateOwner({ armyId, accountId }, (isOwner) => {
+    if (isOwner) {
+      StepsController.create({ name, armyId }, (err, newStep) => {
+        if (err) {
+          console.error(err);
+          return res.status(500).send(err.message);
+        }
+        return res.status(201).send(newStep);
+      });
+    } else {
+      return res.status(403).send("Army not owned by account.");
     }
-    return res.status(201).send(newStep);
-  });
-});
-
-router.post("/:stepId/new-rule", (req, res) => {
-  const { stepId } = req.params;
-  const { name, text } = req.body;
-  if (!name || !text)
-    return res.status(400).send("Rule name and text required");
-
-  StepsController.createRule({ stepId, name, text }, (err, updatedSteps) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).send(err.message);
-    }
-    return res.status(201).send(updatedSteps);
-  });
-});
-
-router.delete("/:stepId/:ruleId", (req, res) => {
-  const { stepId, ruleId } = req.params;
-
-  StepController.deleteRule({ stepId, ruleId }, (err, updatedSteps) => {
-    if (err) {
-      console.error(err);
-      return res.status(500).send(err.message);
-    }
-    return res.status(200).send(updatedSteps);
   });
 });
 

--- a/packages/express-backend/steps/rulesRoutes.js
+++ b/packages/express-backend/steps/rulesRoutes.js
@@ -4,7 +4,8 @@ const StepsController = require("./controller");
 const ArmyController = require("../armies/controller");
 
 router.use("/", (req, res, next) => {
-  const { accountId, armyId } = req.body;
+  const { armyId } = req.body;
+  const { accountid: accountId } = req.headers;
   ArmyController.validateOwner({ armyId, accountId }, (isOwner) => {
     if (isOwner) {
       next();

--- a/packages/express-backend/steps/rulesRoutes.js
+++ b/packages/express-backend/steps/rulesRoutes.js
@@ -1,0 +1,43 @@
+const express = require("express");
+const router = express.Router({ mergeParams: true });
+const StepsController = require("./controller");
+const ArmyController = require("../armies/controller");
+
+router.use("/", (req, res, next) => {
+  const { accountId, armyId } = req.body;
+  ArmyController.validateOwner({ armyId, accountId }, (isOwner) => {
+    if (isOwner) {
+      next();
+    } else {
+      return res.status(403).send("Army not owned by account.");
+    }
+  });
+});
+
+router.post("/create", (req, res) => {
+  const { name, text, stepId } = req.body;
+  if (!name || !text)
+    return res.status(400).send("Rule name and text required");
+
+  StepsController.createRule({ stepId, name, text }, (err, updatedSteps) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send(err.message);
+    }
+    return res.status(201).send(updatedSteps);
+  });
+});
+
+router.delete("/remove", (req, res) => {
+  const { stepId, ruleId } = req.body;
+
+  StepController.deleteRule({ stepId, ruleId }, (err, updatedSteps) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send(err.message);
+    }
+    return res.status(200).send(updatedSteps);
+  });
+});
+
+module.exports = router;

--- a/packages/react-frontend/hooks/useApi.ts
+++ b/packages/react-frontend/hooks/useApi.ts
@@ -27,38 +27,29 @@ type LoginResponse = { id: string; email: string; approved: boolean };
 export const useApi = () => {
   const accountId = useAccountStore((state) => state.accountId);
   //   const session = useAccountStore((state) => state.session);
-  const getGetterUrl = useCallback(
-    (type: urlGetterType) => {
-      let url = `${API_BASE}${ENDPOINTS.get[type]}`;
-      if (accountId) url = url.replace(/<accountId>/gi, accountId);
-      return url;
-    },
-    [accountId]
-  );
 
-  const getPosterUrl = useCallback(
-    (type: urlPosterType) => {
-      let url = `${API_BASE}${ENDPOINTS.post[type]}`;
-      if (accountId) url = url.replace(/<accountId>/gi, accountId);
-      return url;
-    },
-    [accountId]
-  );
+  const getGetUrl = useCallback((type: urlGetterType) => {
+    return `${API_BASE}${ENDPOINTS.get[type]}`;
+  }, []);
+
+  const getPostUrl = useCallback((type: urlPosterType) => {
+    return `${API_BASE}${ENDPOINTS.post[type]}`;
+  }, []);
 
   const getArmies = useCallback(() => {
-    const url = getGetterUrl("armies");
+    const url = getGetUrl("armies");
     return new Promise<UnParsedArmy[] | Error>((res, rej) => {
       axios
         .get(url, { headers: { accountId } })
         .then(({ data }) => res(data))
         .catch(rej);
     });
-  }, [getGetterUrl]);
+  }, [getGetUrl]);
 
   const getArmySteps = useCallback(
     (armyId: string) => {
       if (!accountId) return null;
-      const url = getGetterUrl("army").replace(/<armyId>/gi, armyId);
+      const url = getGetUrl("army").replace(/<armyId>/gi, armyId);
       return new Promise<ArmySteps[] | Error>((res, rej) => {
         axios
           .get(url, { headers: { accountId } })
@@ -66,7 +57,7 @@ export const useApi = () => {
           .catch(rej);
       });
     },
-    [getGetterUrl, accountId]
+    [getGetUrl, accountId]
   );
 
   type postNewRuleProps = {
@@ -77,7 +68,7 @@ export const useApi = () => {
   };
   const postNewRule = useCallback(
     ({ armyId, stepId, name, text }: postNewRuleProps) => {
-      const url = `${API_BASE}${ENDPOINTS.post.rule}`;
+      const url = getPostUrl("rule");
       return new Promise<ArmySteps[] | Error | null>((res, rej) => {
         if (!accountId) return null;
         axios
@@ -86,12 +77,12 @@ export const useApi = () => {
           .catch(rej);
       });
     },
-    [getPosterUrl, accountId]
+    [getPostUrl, accountId]
   );
 
   const login = useCallback(
     ({ email, password }: { email: string; password: string }) => {
-      const url = getGetterUrl("account");
+      const url = getGetUrl("account");
       return new Promise<LoginResponse | Error>((res, rej) => {
         axios
           .get(url, { params: { email, password }, headers: {} })
@@ -101,7 +92,7 @@ export const useApi = () => {
           .catch(rej);
       });
     },
-    [getGetterUrl]
+    [getGetUrl]
   );
 
   return {

--- a/packages/react-frontend/hooks/useApi.ts
+++ b/packages/react-frontend/hooks/useApi.ts
@@ -8,7 +8,7 @@ export const ENDPOINTS = {
   getters: {
     account: "/v1/accounts",
     armies: "/v1/<accountId>/armies",
-    army: "/v1/<accountId>/<armyId>/steps",
+    army: "/v1/steps/<armyId>",
   },
   posters: {
     account: "/v1/accounts/create",
@@ -49,7 +49,7 @@ export const useApi = () => {
     const url = getGetterUrl("armies");
     return new Promise<UnParsedArmy[] | Error>((res, rej) => {
       axios
-        .get(url)
+        .get(url, { headers: { accountId } })
         .then(({ data }) => res(data))
         .catch(rej);
     });
@@ -61,7 +61,7 @@ export const useApi = () => {
       const url = getGetterUrl("army").replace(/<armyId>/gi, armyId);
       return new Promise<ArmySteps[] | Error>((res, rej) => {
         axios
-          .get(url)
+          .get(url, { headers: { accountId } })
           .then(({ data }) => res(data))
           .catch(rej);
       });
@@ -81,7 +81,7 @@ export const useApi = () => {
       return new Promise<ArmySteps[] | Error | null>((res, rej) => {
         if (!accountId) return null;
         axios
-          .post(url, { name, text, accountId, armyId, stepId })
+          .post(url, { name, text, armyId, stepId }, { headers: { accountId } })
           .then(({ data }) => res(data))
           .catch(rej);
       });

--- a/packages/react-frontend/hooks/useApi.ts
+++ b/packages/react-frontend/hooks/useApi.ts
@@ -5,22 +5,22 @@ import { useAccountStore } from "store/account";
 import { ArmySteps, UnParsedArmy } from "store/armies";
 
 export const ENDPOINTS = {
-  getters: {
+  get: {
     account: "/v1/accounts",
-    armies: "/v1/<accountId>/armies",
+    armies: "/v1/armies",
     army: "/v1/steps/<armyId>",
   },
-  posters: {
+  post: {
     account: "/v1/accounts/create",
-    armies: "/v1/<accountId>/armies/create",
+    armies: "/v1/armies/create",
     rule: "/v1/rules/create",
   },
-  deleters: {
+  delete: {
     rule: "/v1/rules/remove",
   },
 };
-type urlGetterType = keyof typeof ENDPOINTS.getters;
-type urlPosterType = keyof typeof ENDPOINTS.posters;
+type urlGetterType = keyof typeof ENDPOINTS.get;
+type urlPosterType = keyof typeof ENDPOINTS.post;
 
 type LoginResponse = { id: string; email: string; approved: boolean };
 
@@ -29,7 +29,7 @@ export const useApi = () => {
   //   const session = useAccountStore((state) => state.session);
   const getGetterUrl = useCallback(
     (type: urlGetterType) => {
-      let url = `${API_BASE}${ENDPOINTS.getters[type]}`;
+      let url = `${API_BASE}${ENDPOINTS.get[type]}`;
       if (accountId) url = url.replace(/<accountId>/gi, accountId);
       return url;
     },
@@ -38,7 +38,7 @@ export const useApi = () => {
 
   const getPosterUrl = useCallback(
     (type: urlPosterType) => {
-      let url = `${API_BASE}${ENDPOINTS.posters[type]}`;
+      let url = `${API_BASE}${ENDPOINTS.post[type]}`;
       if (accountId) url = url.replace(/<accountId>/gi, accountId);
       return url;
     },
@@ -77,7 +77,7 @@ export const useApi = () => {
   };
   const postNewRule = useCallback(
     ({ armyId, stepId, name, text }: postNewRuleProps) => {
-      const url = `${API_BASE}${ENDPOINTS.posters.rule}`;
+      const url = `${API_BASE}${ENDPOINTS.post.rule}`;
       return new Promise<ArmySteps[] | Error | null>((res, rej) => {
         if (!accountId) return null;
         axios

--- a/packages/react-frontend/hooks/useApi.ts
+++ b/packages/react-frontend/hooks/useApi.ts
@@ -13,7 +13,10 @@ export const ENDPOINTS = {
   posters: {
     account: "/v1/accounts/create",
     armies: "/v1/<accountId>/armies/create",
-    rule: "/v1/<accountId>/<armyId>/steps/<stepId>/new-rule",
+    rule: "/v1/rules/create",
+  },
+  deleters: {
+    rule: "/v1/rules/remove",
   },
 };
 type urlGetterType = keyof typeof ENDPOINTS.getters;
@@ -74,13 +77,11 @@ export const useApi = () => {
   };
   const postNewRule = useCallback(
     ({ armyId, stepId, name, text }: postNewRuleProps) => {
-      const url = getPosterUrl("rule")
-        .replace(/<armyId>/gi, armyId)
-        .replace(/<stepId>/gi, stepId);
+      const url = `${API_BASE}${ENDPOINTS.posters.rule}`;
       return new Promise<ArmySteps[] | Error | null>((res, rej) => {
         if (!accountId) return null;
         axios
-          .post(url, { name, text })
+          .post(url, { name, text, accountId, armyId, stepId })
           .then(({ data }) => res(data))
           .catch(rej);
       });


### PR DESCRIPTION
Endpoints were getting way too long and hard to read, especially when doing requests around steps.

IE, `http://localhost:3000/api/v1/63bcd5b40fa7101840a82609/63bcd47e3c6419acae2d13df/steps/63bcd47e3c6419acae2d13ac/63bcd47e3c6419acae2d13ae` because of how account, army, and step id were being passed as query params.

This is now `http://localhost:3000/api/v1/rules/create`

Account ids have been moved to mainly be a request header. Army and step ids have been moved to mainly be apart of the request body.

/api/v1/:accountId/armies | /api/v1/armies
-- | --
GET / | GET /:accountId
POST /create | POST /create
GET /:armyId | [removed]




/api/v1/:accountId/:armyId/steps | /api/v1/steps
-- | --
GET / | GET /:armyId
POST /create | POST /create
POST /:stepId/new-rule | [moved]
DELETE /:stepId/:ruleId | [moved]




[n/a] | /api/v1/rules
-- | --
[n/a] | POST /create
[n/a] | DELETE /remove


